### PR TITLE
Add simple QR code generator service

### DIFF
--- a/shared/src/androidMain/kotlin/org/githut/kmp/qr/QrCodeService.android.kt
+++ b/shared/src/androidMain/kotlin/org/githut/kmp/qr/QrCodeService.android.kt
@@ -1,0 +1,5 @@
+package org.githut.kmp.qr
+
+actual class QrCodeService {
+    actual fun generate(data: String): List<List<Boolean>> = generateSimpleMatrix(data)
+}

--- a/shared/src/commonMain/kotlin/org/githut/kmp/qr/QrCodeService.kt
+++ b/shared/src/commonMain/kotlin/org/githut/kmp/qr/QrCodeService.kt
@@ -1,0 +1,9 @@
+package org.githut.kmp.qr
+
+/**
+ * Simple service for generating QR code data from a string.
+ * The resulting matrix contains `true` for a black pixel and `false` for a white pixel.
+ */
+expect class QrCodeService() {
+    fun generate(data: String): List<List<Boolean>>
+}

--- a/shared/src/commonMain/kotlin/org/githut/kmp/qr/SimpleQrGenerator.kt
+++ b/shared/src/commonMain/kotlin/org/githut/kmp/qr/SimpleQrGenerator.kt
@@ -1,0 +1,21 @@
+package org.githut.kmp.qr
+
+internal const val SIMPLE_QR_SIZE = 21
+
+internal fun generateSimpleMatrix(data: String): List<List<Boolean>> {
+    val bytes = data.encodeToByteArray()
+    val result = MutableList(SIMPLE_QR_SIZE) { MutableList(SIMPLE_QR_SIZE) { false } }
+    var bitIndex = 0
+    for (byte in bytes) {
+        for (i in 0 until 8) {
+            if (bitIndex >= SIMPLE_QR_SIZE * SIMPLE_QR_SIZE) break
+            val row = bitIndex / SIMPLE_QR_SIZE
+            val col = bitIndex % SIMPLE_QR_SIZE
+            val bit = ((byte.toInt() shr i) and 1) == 1
+            result[row][col] = bit
+            bitIndex++
+        }
+        if (bitIndex >= SIMPLE_QR_SIZE * SIMPLE_QR_SIZE) break
+    }
+    return result
+}

--- a/shared/src/commonTest/kotlin/org/githut/kmp/qr/SharedCommonTest.kt
+++ b/shared/src/commonTest/kotlin/org/githut/kmp/qr/SharedCommonTest.kt
@@ -9,4 +9,11 @@ class SharedCommonTest {
     fun example() {
         assertEquals(3, 1 + 2)
     }
+
+    @Test
+    fun qrCodeGeneration_size() {
+        val matrix = QrCodeService().generate("test")
+        assertEquals(SIMPLE_QR_SIZE, matrix.size)
+        assertEquals(SIMPLE_QR_SIZE, matrix.first().size)
+    }
 }

--- a/shared/src/iosMain/kotlin/org/githut/kmp/qr/QrCodeService.ios.kt
+++ b/shared/src/iosMain/kotlin/org/githut/kmp/qr/QrCodeService.ios.kt
@@ -1,0 +1,5 @@
+package org.githut.kmp.qr
+
+actual class QrCodeService {
+    actual fun generate(data: String): List<List<Boolean>> = generateSimpleMatrix(data)
+}

--- a/shared/src/jvmMain/kotlin/org/githut/kmp/qr/QrCodeService.jvm.kt
+++ b/shared/src/jvmMain/kotlin/org/githut/kmp/qr/QrCodeService.jvm.kt
@@ -1,0 +1,5 @@
+package org.githut.kmp.qr
+
+actual class QrCodeService {
+    actual fun generate(data: String): List<List<Boolean>> = generateSimpleMatrix(data)
+}

--- a/shared/src/wasmJsMain/kotlin/org/githut/kmp/qr/QrCodeService.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/org/githut/kmp/qr/QrCodeService.wasmJs.kt
@@ -1,0 +1,5 @@
+package org.githut.kmp.qr
+
+actual class QrCodeService {
+    actual fun generate(data: String): List<List<Boolean>> = generateSimpleMatrix(data)
+}


### PR DESCRIPTION
## Summary
- add expect `QrCodeService` to `shared` module
- provide simple matrix generation algorithm in common code
- implement actual `QrCodeService` for Android, JVM, iOS and WASM
- test that generated matrix has expected size

## Testing
- `./gradlew test --no-daemon --offline` *(fails: No route to host)*