### PR TITLE
Introduce LogicQrCode type

### DIFF
--- a/shared/src/androidMain/kotlin/org/githut/kmp/qr/QrCodeService.android.kt
+++ b/shared/src/androidMain/kotlin/org/githut/kmp/qr/QrCodeService.android.kt
@@ -1,5 +1,5 @@
 package org.githut.kmp.qr
 
 actual class QrCodeService {
-    actual fun generate(data: String): List<List<Boolean>> = generateSimpleMatrix(data)
+    actual fun generate(data: String): LogicQrCode = generateSimpleMatrix(data)
 }

--- a/shared/src/commonMain/kotlin/org/githut/kmp/qr/LogicQrCode.kt
+++ b/shared/src/commonMain/kotlin/org/githut/kmp/qr/LogicQrCode.kt
@@ -1,0 +1,7 @@
+package org.githut.kmp.qr
+
+/**
+ * Represents the logical QR code matrix where `true` denotes a black pixel
+ * and `false` denotes a white pixel.
+ */
+data class LogicQrCode(val matrix: List<List<Boolean>>)

--- a/shared/src/commonMain/kotlin/org/githut/kmp/qr/QrCodeService.kt
+++ b/shared/src/commonMain/kotlin/org/githut/kmp/qr/QrCodeService.kt
@@ -5,5 +5,5 @@ package org.githut.kmp.qr
  * The resulting matrix contains `true` for a black pixel and `false` for a white pixel.
  */
 expect class QrCodeService() {
-    fun generate(data: String): List<List<Boolean>>
+    fun generate(data: String): LogicQrCode
 }

--- a/shared/src/commonMain/kotlin/org/githut/kmp/qr/SimpleQrGenerator.kt
+++ b/shared/src/commonMain/kotlin/org/githut/kmp/qr/SimpleQrGenerator.kt
@@ -2,7 +2,7 @@ package org.githut.kmp.qr
 
 internal const val SIMPLE_QR_SIZE = 21
 
-internal fun generateSimpleMatrix(data: String): List<List<Boolean>> {
+internal fun generateSimpleMatrix(data: String): LogicQrCode {
     val bytes = data.encodeToByteArray()
     val result = MutableList(SIMPLE_QR_SIZE) { MutableList(SIMPLE_QR_SIZE) { false } }
     var bitIndex = 0
@@ -17,5 +17,5 @@ internal fun generateSimpleMatrix(data: String): List<List<Boolean>> {
         }
         if (bitIndex >= SIMPLE_QR_SIZE * SIMPLE_QR_SIZE) break
     }
-    return result
+    return LogicQrCode(result)
 }

--- a/shared/src/commonTest/kotlin/org/githut/kmp/qr/SharedCommonTest.kt
+++ b/shared/src/commonTest/kotlin/org/githut/kmp/qr/SharedCommonTest.kt
@@ -12,8 +12,8 @@ class SharedCommonTest {
 
     @Test
     fun qrCodeGeneration_size() {
-        val matrix = QrCodeService().generate("test")
-        assertEquals(SIMPLE_QR_SIZE, matrix.size)
-        assertEquals(SIMPLE_QR_SIZE, matrix.first().size)
+        val qr = QrCodeService().generate("test")
+        assertEquals(SIMPLE_QR_SIZE, qr.matrix.size)
+        assertEquals(SIMPLE_QR_SIZE, qr.matrix.first().size)
     }
 }

--- a/shared/src/iosMain/kotlin/org/githut/kmp/qr/QrCodeService.ios.kt
+++ b/shared/src/iosMain/kotlin/org/githut/kmp/qr/QrCodeService.ios.kt
@@ -1,5 +1,5 @@
 package org.githut.kmp.qr
 
 actual class QrCodeService {
-    actual fun generate(data: String): List<List<Boolean>> = generateSimpleMatrix(data)
+    actual fun generate(data: String): LogicQrCode = generateSimpleMatrix(data)
 }

--- a/shared/src/jvmMain/kotlin/org/githut/kmp/qr/QrCodeService.jvm.kt
+++ b/shared/src/jvmMain/kotlin/org/githut/kmp/qr/QrCodeService.jvm.kt
@@ -1,5 +1,10 @@
 package org.githut.kmp.qr
 
+import java.net.URL
+
 actual class QrCodeService {
-    actual fun generate(data: String): List<List<Boolean>> = generateSimpleMatrix(data)
+    actual fun generate(data: String): LogicQrCode {
+        val url = URL(data)
+        return generateSimpleMatrix(url.toExternalForm())
+    }
 }

--- a/shared/src/wasmJsMain/kotlin/org/githut/kmp/qr/QrCodeService.wasmJs.kt
+++ b/shared/src/wasmJsMain/kotlin/org/githut/kmp/qr/QrCodeService.wasmJs.kt
@@ -1,5 +1,5 @@
 package org.githut.kmp.qr
 
 actual class QrCodeService {
-    actual fun generate(data: String): List<List<Boolean>> = generateSimpleMatrix(data)
+    actual fun generate(data: String): LogicQrCode = generateSimpleMatrix(data)
 }


### PR DESCRIPTION
## Summary
- model logical QR code pixels with `LogicQrCode`
- return the new type from `QrCodeService`
- treat input as a URL on the JVM implementation
- adjust unit tests

## Testing
- `./gradlew build --no-daemon` *(fails: No route to host)*