### PR TITLE
Add ZXing QR example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,25 @@ We would appreciate your feedback on Compose/Web and Kotlin/Wasm in the public S
 If you face any issues, please report them on [YouTrack](https://youtrack.jetbrains.com/newIssue?project=CMP).
 
 You can open the web application by running the `:composeApp:wasmJsBrowserDevelopmentRun` Gradle task.
+
+## ZXing QR Code Example
+
+The server module contains a Java utility for creating QR code images using the
+[ZXing](https://github.com/zxing/zxing) library. Include the following
+dependencies in your Gradle build:
+
+```kotlin
+implementation(libs.zxing.core)
+implementation(libs.zxing.javase)
+```
+
+The `QrCodeService` in the `jvm` source set also relies on ZXing to produce a
+`LogicQrCode` instance representing the QR matrix.
+
+You can then generate a PNG file with:
+
+```java
+try (FileOutputStream out = new FileOutputStream("qr.png")) {
+    ZxingQrGenerator.writeQrToStream("hello world", 300, out);
+}
+```

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ kotlin = "2.1.21"
 kotlinx-coroutines = "1.10.2"
 ktor = "3.1.3"
 logback = "1.5.18"
+zxing = "3.5.1"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -35,6 +36,8 @@ logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 ktor-serverCore = { module = "io.ktor:ktor-server-core-jvm", version.ref = "ktor" }
 ktor-serverNetty = { module = "io.ktor:ktor-server-netty-jvm", version.ref = "ktor" }
 ktor-serverTestHost = { module = "io.ktor:ktor-server-test-host-jvm", version.ref = "ktor" }
+zxing-core = { module = "com.google.zxing:core", version.ref = "zxing" }
+zxing-javase = { module = "com.google.zxing:javase", version.ref = "zxing" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -18,6 +18,8 @@ dependencies {
     implementation(libs.logback)
     implementation(libs.ktor.serverCore)
     implementation(libs.ktor.serverNetty)
+    implementation(libs.zxing.core)
+    implementation(libs.zxing.javase)
     testImplementation(libs.ktor.serverTestHost)
     testImplementation(libs.kotlin.testJunit)
 }

--- a/server/src/main/java/org/githut/kmp/qr/ZxingExample.java
+++ b/server/src/main/java/org/githut/kmp/qr/ZxingExample.java
@@ -1,0 +1,24 @@
+package org.githut.kmp.qr;
+
+import com.google.zxing.WriterException;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+
+/**
+ * Example application that creates a QR code PNG using {@link ZxingQrGenerator}.
+ */
+public class ZxingExample {
+    public static void main(String[] args) throws IOException, WriterException {
+        if (args.length != 2) {
+            System.err.println("Usage: ZxingExample <data> <output file>");
+            return;
+        }
+        String data = args[0];
+        String output = args[1];
+        try (FileOutputStream fos = new FileOutputStream(output)) {
+            ZxingQrGenerator.writeQrToStream(data, 300, fos);
+        }
+        System.out.println("QR code written to " + output);
+    }
+}

--- a/server/src/main/java/org/githut/kmp/qr/ZxingQrGenerator.java
+++ b/server/src/main/java/org/githut/kmp/qr/ZxingQrGenerator.java
@@ -1,0 +1,29 @@
+package org.githut.kmp.qr;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Utility class for generating QR codes using ZXing.
+ */
+public class ZxingQrGenerator {
+    /**
+     * Writes a QR code PNG representing the provided text to the given output stream.
+     *
+     * @param text data to encode
+     * @param size size of the square QR code image
+     * @param output output stream to write the PNG data to
+     */
+    public static void writeQrToStream(String text, int size, OutputStream output)
+            throws WriterException, IOException {
+        QRCodeWriter writer = new QRCodeWriter();
+        BitMatrix matrix = writer.encode(text, BarcodeFormat.QR_CODE, size, size);
+        MatrixToImageWriter.writeToStream(matrix, "PNG", output);
+    }
+}

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -43,6 +43,9 @@ kotlin {
         commonMain.dependencies {
             // put your Multiplatform dependencies here
         }
+        jvmMain.dependencies {
+            implementation(libs.zxing.core)
+        }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
         }

--- a/shared/src/jvmMain/kotlin/org/githut/kmp/qr/QrCodeService.jvm.kt
+++ b/shared/src/jvmMain/kotlin/org/githut/kmp/qr/QrCodeService.jvm.kt
@@ -1,10 +1,20 @@
 package org.githut.kmp.qr
 
-import java.net.URL
+import com.google.zxing.BarcodeFormat
+import com.google.zxing.qrcode.QRCodeWriter
 
+/**
+ * JVM implementation of [QrCodeService] that delegates QR code generation to
+ * the ZXing library while returning the logical matrix expected by the shared
+ * code.
+ */
 actual class QrCodeService {
     actual fun generate(data: String): LogicQrCode {
-        val url = URL(data)
-        return generateSimpleMatrix(url.toExternalForm())
+        val writer = QRCodeWriter()
+        val matrix = writer.encode(data, BarcodeFormat.QR_CODE, SIMPLE_QR_SIZE, SIMPLE_QR_SIZE)
+        val result = List(matrix.height) { y ->
+            List(matrix.width) { x -> matrix.get(x, y) }
+        }
+        return LogicQrCode(result)
     }
 }


### PR DESCRIPTION
## Summary
- add ZXing library definitions to version catalog
- include ZXing dependencies in the server module
- add Java utilities demonstrating QR code generation with ZXing
- rely on ZXing in the JVM implementation of `QrCodeService`
- document ZXing usage in README

## Testing
- `./gradlew --version` *(fails: No route to host)*