### PR TITLE
Add QR input compose UI

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/githut/kmp/qr/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/githut/kmp/qr/App.kt
@@ -1,43 +1,47 @@
 package org.githut.kmp.qr
 
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.safeContentPadding
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.runtime.*
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import org.jetbrains.compose.resources.painterResource
-import org.jetbrains.compose.ui.tooling.preview.Preview
-
-import qr_generator.composeapp.generated.resources.Res
-import qr_generator.composeapp.generated.resources.compose_multiplatform
-
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 @Composable
 @Preview
 fun App() {
     MaterialTheme {
-        var showContent by remember { mutableStateOf(false) }
+        var url by remember { mutableStateOf("") }
+        val qrService = remember { QrCodeService() }
+
         Column(
             modifier = Modifier
                 .safeContentPadding()
                 .fillMaxSize(),
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
-            Button(onClick = { showContent = !showContent }) {
-                Text("Click me!")
-            }
-            AnimatedVisibility(showContent) {
-                val greeting = remember { Greeting().greet() }
-                Column(Modifier.fillMaxWidth(), horizontalAlignment = Alignment.CenterHorizontally) {
-                    Image(painterResource(Res.drawable.compose_multiplatform), null)
-                    Text("Compose: $greeting")
-                }
+            TextField(
+                modifier = Modifier.fillMaxWidth(),
+                value = url,
+                onValueChange = { url = it },
+                label = { Text("URL") },
+                singleLine = true,
+            )
+            Spacer(Modifier.height(16.dp))
+            if (url.isNotBlank()) {
+                val qr = remember(url) { qrService.generate(url) }
+                QrCodeImage(qr)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/githut/kmp/qr/QrCodeComposable.kt
+++ b/composeApp/src/commonMain/kotlin/org/githut/kmp/qr/QrCodeComposable.kt
@@ -1,0 +1,33 @@
+package org.githut.kmp.qr
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.size
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+/**
+ * Draws the given [LogicQrCode] matrix on a Canvas.
+ */
+@Composable
+fun QrCodeImage(qr: LogicQrCode, modifier: Modifier = Modifier, pixelSize: Dp = 8.dp) {
+    val sizeDp = pixelSize * qr.matrix.size
+    Canvas(modifier = modifier.size(sizeDp)) {
+        val scale = size.width / qr.matrix.size
+        for (y in qr.matrix.indices) {
+            for (x in qr.matrix[y].indices) {
+                if (qr.matrix[y][x]) {
+                    drawRect(
+                        color = Color.Black,
+                        topLeft = Offset(x * scale, y * scale),
+                        size = Size(scale, scale)
+                    )
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update the shared Compose `App` to show a URL text field and generated QR
- add `QrCodeImage` composable for rendering logical QR matrices

## Testing
- `./gradlew test --no-daemon` *(fails: No route to host)*